### PR TITLE
Set metadata decoding to UTF-16

### DIFF
--- a/pyaimp.py
+++ b/pyaimp.py
@@ -217,7 +217,7 @@ class Client:
 
         meta_data_unpacked = dict(zip(AIMPRemoteAccessPackFormat.keys(), struct.unpack(pack_format, meta_data_raw)))
 
-        track_data = mapped_file.read(mapped_file.size() - mapped_file.tell()).decode().replace('\x00', '')
+        track_data = mapped_file.read(mapped_file.size() - mapped_file.tell()).decode('UTF-16').replace('\x00', '')
 
         mapped_file.close()
 


### PR DESCRIPTION
Leaving the metadata to UTF-8 causes issues with tracks that use special characters in their metadata, sometimes crashing completely.
![image](https://user-images.githubusercontent.com/15108194/58751376-92d5f600-8495-11e9-8b74-6e85e75102bf.png)
![image](https://user-images.githubusercontent.com/15108194/58751412-f102d900-8495-11e9-8771-ddbf2593327a.png)


Switching the metadata to UTF-16 fixes these issues and the library no longer crashes when parsing certain characters.
![image](https://user-images.githubusercontent.com/15108194/58751400-c7e24880-8495-11e9-89cf-9372dfb0815c.png)
![image](https://user-images.githubusercontent.com/15108194/58751406-dcbedc00-8495-11e9-97fc-3c92fadc2b4d.png)

